### PR TITLE
Deformable strip convolutions

### DIFF
--- a/ops_dcnv3/functions/dcnv3_func.py
+++ b/ops_dcnv3/functions/dcnv3_func.py
@@ -23,7 +23,7 @@ class DCNv3Function(Function):
             ctx, input, offset, mask,
             kernel_h, kernel_w, stride_h, stride_w,
             pad_h, pad_w, dilation_h, dilation_w,
-            group, group_channels, offset_scale, im2col_step):
+            group, group_channels, offset_scale, strip_conv, im2col_step):
         ctx.kernel_h = kernel_h
         ctx.kernel_w = kernel_w
         ctx.stride_h = stride_h
@@ -35,12 +35,13 @@ class DCNv3Function(Function):
         ctx.group = group
         ctx.group_channels = group_channels
         ctx.offset_scale = offset_scale
+        ctx.strip_conv = strip_conv
         ctx.im2col_step = im2col_step
         output = DCNv3.dcnv3_forward(
             input, offset, mask, kernel_h,
             kernel_w, stride_h, stride_w, pad_h,
             pad_w, dilation_h, dilation_w, group,
-            group_channels, offset_scale, ctx.im2col_step)
+            group_channels, offset_scale, strip_conv, ctx.im2col_step)
         ctx.save_for_backward(input, offset, mask)
 
         return output
@@ -55,7 +56,7 @@ class DCNv3Function(Function):
                 input, offset, mask, ctx.kernel_h,
                 ctx.kernel_w, ctx.stride_h, ctx.stride_w, ctx.pad_h,
                 ctx.pad_w, ctx.dilation_h, ctx.dilation_w, ctx.group,
-                ctx.group_channels, ctx.offset_scale, grad_output.contiguous(), ctx.im2col_step)
+                ctx.group_channels, ctx.offset_scale, ctx.strip_conv, grad_output.contiguous(), ctx.im2col_step)
 
         return grad_input, grad_offset, grad_mask, \
             None, None, None, None, None, None, None, None, None, None, None, None
@@ -63,7 +64,7 @@ class DCNv3Function(Function):
     @staticmethod
     def symbolic(g, input, offset, mask, kernel_h, kernel_w, stride_h,
                  stride_w, pad_h, pad_w, dilation_h, dilation_w, group,
-                 group_channels, offset_scale, im2col_step):
+                 group_channels, offset_scale, strip_conv, im2col_step):
         """Symbolic function for mmdeploy::DCNv3.
 
         Returns:
@@ -85,6 +86,7 @@ class DCNv3Function(Function):
             group_i=int(group),
             group_channels_i=int(group_channels),
             offset_scale_f=float(offset_scale),
+            strip_conv_i=int(strip_conv),
             im2col_step_i=int(im2col_step),
         )
 

--- a/ops_dcnv3/modules/dcnv3.py
+++ b/ops_dcnv3/modules/dcnv3.py
@@ -350,7 +350,7 @@ class DCNv3(nn.Module):
             norm_layer='LN',
             center_feature_scale=False,
             use_dcn_v4_op=False,
-            strip_conv=False
+            strip_conv=0
             ):
         """
         DCNv3 Module
@@ -404,7 +404,7 @@ class DCNv3(nn.Module):
                 'channels_last'),
             build_act_layer(act_layer))
         self.strip_conv = strip_conv
-        if self.strip_conv:
+        if self.strip_conv == 1:
             self.offset = nn.Linear(
             channels,
             group * kernel_size * kernel_size)

--- a/ops_dcnv3/modules/dcnv3.py
+++ b/ops_dcnv3/modules/dcnv3.py
@@ -350,6 +350,7 @@ class DCNv3(nn.Module):
             norm_layer='LN',
             center_feature_scale=False,
             use_dcn_v4_op=False,
+            strip_conv=False
             ):
         """
         DCNv3 Module
@@ -402,9 +403,15 @@ class DCNv3(nn.Module):
                 'channels_first',
                 'channels_last'),
             build_act_layer(act_layer))
-        self.offset = nn.Linear(
+        self.strip_conv = strip_conv
+        if self.strip_conv:
+            self.offset = nn.Linear(
             channels,
-            group * kernel_size * kernel_size * 2)
+            group * kernel_size * kernel_size)
+        else:
+            self.offset = nn.Linear(
+                channels,
+                group * kernel_size * kernel_size * 2)
         self.mask = nn.Linear(
             channels,
             group * kernel_size * kernel_size)
@@ -446,6 +453,7 @@ class DCNv3(nn.Module):
                 self.dilation, self.dilation,
                 self.group, self.group_channels,
                 self.offset_scale,
+                self.strip_conv,
                 256)
         else:
             # DCNv4 combines offset and weight mask into one tensor `offset_mask`.
@@ -482,6 +490,8 @@ class DCNv3(nn.Module):
             x = x * (1 - center_feature_scale) + x_proj * center_feature_scale
 
         return x
+
+
 
 # This is the original implementation from InternImage
 # Renamed due to import issues

--- a/ops_dcnv3/src/cuda/dcnv3_cuda.h
+++ b/ops_dcnv3/src/cuda/dcnv3_cuda.h
@@ -19,7 +19,7 @@ at::Tensor dcnv3_cuda_forward(const at::Tensor &input, const at::Tensor &offset,
                               const int pad_w, const int dilation_h,
                               const int dilation_w, const int group,
                               const int group_channels,
-                              const float offset_scale, const int im2col_step);
+                              const float offset_scale, const int strip_conv, const int im2col_step);
 
 std::vector<at::Tensor>
 dcnv3_cuda_backward(const at::Tensor &input, const at::Tensor &offset,
@@ -27,5 +27,5 @@ dcnv3_cuda_backward(const at::Tensor &input, const at::Tensor &offset,
                     const int kernel_w, const int stride_h, const int stride_w,
                     const int pad_h, const int pad_w, const int dilation_h,
                     const int dilation_w, const int group,
-                    const int group_channels, const float offset_scale,
+                    const int group_channels, const float offset_scale, const int strip_conv,
                     const at::Tensor &grad_output, const int im2col_step);

--- a/ops_dcnv3/src/dcnv3.h
+++ b/ops_dcnv3/src/dcnv3.h
@@ -23,13 +23,13 @@ at::Tensor dcnv3_forward(const at::Tensor &input, const at::Tensor &offset,
                          const int stride_w, const int pad_h, const int pad_w,
                          const int dilation_h, const int dilation_w,
                          const int group, const int group_channels,
-                         const float offset_scale, const int im2col_step) {
+                         const float offset_scale, const int strip_conv, const int im2col_step) {
     if (input.type().is_cuda()) {
 #ifdef WITH_CUDA
         return dcnv3_cuda_forward(input, offset, mask, kernel_h, kernel_w,
                                   stride_h, stride_w, pad_h, pad_w, dilation_h,
                                   dilation_w, group, group_channels,
-                                  offset_scale, im2col_step);
+                                  offset_scale, strip_conv, im2col_step);
 #else
         AT_ERROR("Not compiled with GPU support");
 #endif
@@ -43,14 +43,14 @@ dcnv3_backward(const at::Tensor &input, const at::Tensor &offset,
                const int stride_h, const int stride_w, const int pad_h,
                const int pad_w, const int dilation_h, const int dilation_w,
                const int group, const int group_channels,
-               const float offset_scale, const at::Tensor &grad_output,
+               const float offset_scale, const int strip_conv, const at::Tensor &grad_output,
                const int im2col_step) {
     if (input.type().is_cuda()) {
 #ifdef WITH_CUDA
         return dcnv3_cuda_backward(input, offset, mask, kernel_h, kernel_w,
                                    stride_h, stride_w, pad_h, pad_w, dilation_h,
                                    dilation_w, group, group_channels,
-                                   offset_scale, grad_output, im2col_step);
+                                   offset_scale, strip_conv, grad_output, im2col_step);
 #else
         AT_ERROR("Not compiled with GPU support");
 #endif


### PR DESCRIPTION
Modified dcnv3 to handle singel dimensional offsets. 
When using strip convolutions we want the offset to be calculated in the opposite direction of the filter.
